### PR TITLE
SSHKey fingerprint handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules/
 # build destination
 build/
 
+# dist destination
+dist/
+
 # idea
 .idea
 *.iml
@@ -12,4 +15,4 @@ build/
 *~
 
 # log files
-*.log
+*.log*

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -296,7 +296,7 @@ class SSHKeyAPI {
     remove(key) {
         return new Promise((resolve, reject) => {
             $.ajax({
-                url: `${this.config.auth_url}/api/keys/${key.fingerprint}`,
+                url: `${this.config.auth_url}/api/keys?fingerprint=${encodeURIComponent(key.fingerprint)}`,
                 type: "DELETE",
                 headers: { Authorization: `Bearer ${this.config.token.jti}` },
                 dataType: "json",


### PR DESCRIPTION
Depends on gin-auth pull request [#92](https://github.com/G-Node/gin-auth/pull/92).

Removes ssh key fingerprint from url hierarchical part and adds it as url query part.
