### PR TITLE
Fix empty repo display

### DIFF
--- a/src/js/comp/repo/RepoFiles.vue
+++ b/src/js/comp/repo/RepoFiles.vue
@@ -133,7 +133,7 @@
                                 this.content_files = c_f
                             }).catch((error) => {
                                 if (error.code === 404) {
-                                    this.alertWarning("This path does not exist")
+                                    this.alertWarning("Repository contains no files")
                                 } else {
                                     this.reportError(error)
                                 }

--- a/src/js/comp/repo/RepoReadme.vue
+++ b/src/js/comp/repo/RepoReadme.vue
@@ -50,9 +50,6 @@
                                                 },
                                                 (error) => {
                                                     this.readme = no_readme
-                                                    // TODO this is probably not the best way to deal with
-                                                    // not found entities.
-                                                    this.reportError(error)
                                                 }
                                         )
                                         break
@@ -63,9 +60,6 @@
                             },
                             (error) => {
                                 this.readme = no_readme
-                                // TODO this is probably not the best way to deal
-                                // with not found repositories
-                                this.reportError(error)
                             }
                     )
                 }


### PR DESCRIPTION
When a repository has been created via gin-ui it has no proper commits. Trying to read files from such a repository broke the display page of the respective repository. This fixes the display and allows editing of the repository settings.