### PR TITLE
Enable set visbility when creating repository

### DIFF
--- a/src/js/comp/repo/RepoCreate.vue
+++ b/src/js/comp/repo/RepoCreate.vue
@@ -22,7 +22,7 @@
                 <div class="form-group">
                     <div class="col-sm-10 col-sm-offset-2 checkbox">
                         <label for="public">
-                            <input type="checkbox" id="public" v-model="form.is_public"> Make Repository Public
+                            <input type="checkbox" id="public" v-model="form.public"> Make Repository Public
                         </label>
                     </div>
                 </div>
@@ -47,7 +47,7 @@
                 form: {
                     name: null,
                     description: null,
-                    is_public: false
+                    public: false
                 }
             }
         },
@@ -80,7 +80,7 @@
             reset() {
                 this.form.name = null
                 this.form.description = null
-                this.form.is_public = false
+                this.form.public = false
             }
         }
     }

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -514,7 +514,7 @@ class RepoAPI {
         return new Promise((resolve, reject) => {
             let name = repo_form.name || ""
             if (!name.match(/^[a-zA-Z0-9_\-]*$/)) {
-                reject(Error("Repository name must only contain alphanumeric characters"))
+                reject(Error("Use only alphanumeric characters without whitespaces as repository name."))
                 return
             }
 


### PR DESCRIPTION
- closes #46
- improve error message on repo create fail due to whitespace in repo name.