### PR TITLE
Collaborator handling

### DIFF
--- a/src/js/comp/repo/Repo.vue
+++ b/src/js/comp/repo/Repo.vue
@@ -44,8 +44,8 @@
 
     event.init()
 
-// TODO should params.username on this page and its child pages not actually be ownername?
-// TODO also probably better change params.repository to reponame
+    // TODO should params.username on this page and its child pages not actually be ownername?
+    // TODO Also probably change params.repository to reponame.
 
     export default {
         data() {
@@ -101,7 +101,7 @@
                     const promise = api.repos.getRepo(params.username, params.repository)
                     promise.then(
                             (repo) => {
-                                this.repository = Object.assign({}, repo, { Shared: [] })
+                                this.repository = Object.assign({}, repo, { Shared: {} })
                                 const co_promise = api.repos.getRepoCollaborators(params.username, params.repository)
                                 co_promise.then(
                                         (collaborators) => {

--- a/src/js/comp/repo/Repo.vue
+++ b/src/js/comp/repo/Repo.vue
@@ -67,7 +67,9 @@
 
                     var collaborator
                     if (repo.Shared.length !== undefined) {
-                        collaborator = repo.Shared.map(coll => { return coll.User })
+                        collaborator = repo.Shared
+                                    .filter((coll) => coll.AccessLevel === "is-admin")
+                                    .map(coll => { return coll.User })
                     }
 
                     return name && repo && (repo.Owner === name || (collaborator && collaborator.indexOf(name) >= 0))

--- a/src/js/comp/repo/Repo.vue
+++ b/src/js/comp/repo/Repo.vue
@@ -65,7 +65,12 @@
                     const name = this.account ? this.account.login : null
                     const repo = this.repository
 
-                    return name && repo && (repo.Owner === name || repo.Shared.indexOf(name) >= 0)
+                    var collaborator
+                    if (repo.Shared.length !== undefined) {
+                        collaborator = repo.Shared.map(coll => { return coll.User })
+                    }
+
+                    return name && repo && (repo.Owner === name || (collaborator && collaborator.indexOf(name) >= 0))
                 }
             }
         },

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -109,6 +109,8 @@
     export default {
         data() {
             return {
+                permissions: ["can-pull", "can-push", "is-admin"],
+                default_permission: "can-pull",
                 form: {
                     description: this.repository.Description,
                     is_public: this.repository.Public,
@@ -156,25 +158,22 @@
                     const promise = api.accounts.get(login_name)
                     promise.then(
                         (acc) => {
+                            this.select.match = null
+                            this.select.text = null
+                            this.select.all = []
+
+                            // Add account login as collaborator at gin-repo with default access level
                             const put_promise = api.repos.putCollaborator(this.$route.params.username,
                                                                             this.$route.params.repository,
                                                                             login_name,
-                                                                            { Permission: "can-pull" })
+                                                                            { Permission: this.default_permission })
                             put_promise.then(
                                     () => {
-                                        this.select.match = null
-                                        this.select.text = null
-                                        this.select.all = []
-
                                         event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
                                         this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
                                         this.alertSuccess("Collaborator added")
                                     },
                                     (error) => {
-                                        this.select.match = null
-                                        this.select.text = null
-                                        this.select.all = []
-
                                         // TODO this is a hack; this promise always defaults to error,
                                         // even if the REST call returns status OK, but don't see
                                         // the reason at the moment.

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -23,7 +23,7 @@
                         </div>
                         <div class="form-group">
                             <div class="col-sm-offset-2 col-sm-10">
-                                <button type="submit" class="btn btn-default" @click="reset">Reset</button>
+                                <button type="submit" class="btn btn-default" @click="resetSettings">Reset</button>
                                 <button type="submit" class="btn btn-primary" @click="saveSettings">Save</button>
                             </div>
                         </div>
@@ -195,15 +195,11 @@
                     selected.active = false
                     this.select.text = selected.login
                 } else if (this.select.match === login_name) {
-                    // Check if the account is actually available at gin-auth
+                    // Check if the account is actually available at gin-auth.
                     const promise = api.accounts.get(login_name)
                     promise.then(
                         (acc) => {
-                            this.select.match = null
-                            this.select.text = null
-                            this.select.all = []
-
-                            // Add account login as collaborator at gin-repo with default access level
+                            // Put gin-auth account login as collaborator to gin-repo with default access level.
                             const put_promise = api.repos.putCollaborator(this.$route.params.username,
                                                                             this.$route.params.repository,
                                                                             login_name,
@@ -221,12 +217,12 @@
                             )
                         },
                         (error) => {
-                            this.select.match = null
-                            this.select.text = null
-                            this.select.all = []
                             this.alertError(error)
                         }
                     )
+                    this.select.match = null
+                    this.select.text = null
+                    this.select.all = []
                 }
             },
 
@@ -260,7 +256,6 @@
                     // Check if this could be done more efficiently to reduce either the number of
                     // requests all together or at least the amount of transferred data using an
                     // eTag for the account information.
-                    // TODO promise currently does not deal with the reject case.
                     const promise = api.accounts.search(encodeURIComponent(text))
                     promise.then(
                         (accounts) => {
@@ -279,6 +274,9 @@
                                 this.select.match = null
                             }
                             this.select.all = accounts
+                        },
+                        (error) => {
+                            this.alertError(error)
                         }
                     )
                 } else {
@@ -313,19 +311,10 @@
                 }
             },
 
-            reset() {
-                // TODO shared should actually be removed from this reset,
-                // but it is currently still too entangled in the code above.
+            resetSettings() {
                 this.form = {
                     description: this.repository.Description,
                     is_public: this.repository.Public,
-                    shared: this.repository.Shared
-                }
-                this.form.shared.sort(sortCollaborators)
-                this.select = {
-                    match: null,
-                    text: null,
-                    all: []
                 }
             }
         },

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -162,7 +162,7 @@
                             const put_promise = api.repos.putCollaborator(this.$route.params.username,
                                                                             this.$route.params.repository,
                                                                             login_name,
-                                                                            { Permission: "can-push" })
+                                                                            { Permission: "can-pull" })
                             put_promise.then(
                                     () => {
                                         console.log("proper put")

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -314,10 +314,8 @@
             },
 
             resetSettings() {
-                this.form = {
-                    description: this.repository.Description,
-                    is_public: this.repository.Public,
-                }
+                this.form.description = this.repository.Description
+                this.form.is_public = this.repository.Public
             }
         },
 

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -48,10 +48,13 @@
                                             <td>{{ text.User }}</td>
                                             <td class="text-right">
                                                 <span v-for="level in permissions">
-                                                    <button v-if="text.AccessLevel === level" class="btn btn-success btn-xs"
-                                                            @click="updateCollaborator(text.User, level)">{{ level }}</button>
-                                                    <button v-if="text.AccessLevel !== level" class="btn btn-xs"
-                                                            @click="updateCollaborator(text.User, level)">{{ level }}</button>
+                                                    <button v-if="(permissions.indexOf(text.AccessLevel) > -1 &&
+                                                            permissions.indexOf(level) <= permissions.indexOf(text.AccessLevel))"
+                                                            @click="updateCollaborator(text.User, level)"
+                                                            class="btn btn-success btn-xs">{{ level }}</button>
+                                                    <button v-else
+                                                            @click="updateCollaborator(text.User, level)"
+                                                            class="btn btn-xs">{{ level }}</button>
                                                 </span>
                                             </td>
                                             <td class="text-right">

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -47,6 +47,14 @@
                                         <tr v-for="text in form.shared">
                                             <td>{{ text.User }}</td>
                                             <td class="text-right">
+                                                <span v-for="level in permissions">
+                                                    <button v-if="text.AccessLevel === level" class="btn btn-success btn-xs"
+                                                            @click="updateCollaborator(text.User, level)">{{ level }}</button>
+                                                    <button v-if="text.AccessLevel !== level" class="btn btn-xs"
+                                                            @click="updateCollaborator(text.User, level)">{{ level }}</button>
+                                                </span>
+                                            </td>
+                                            <td class="text-right">
                                                 <button class="btn btn-danger btn-xs" @click="removeShare(text.User)">remove</button>
                                             </td>
                                         </tr>

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -114,6 +114,10 @@
         return parts.length > 0 ? parts.join(" ") : acc.login
     }
 
+    function sortCollaborators(a,b) {
+        return a.User.localeCompare(b.User)
+    }
+
     export default {
         data() {
             return {
@@ -130,6 +134,10 @@
                     all: []
                 }
             }
+        },
+
+        mounted() {
+            this.form.shared.sort(sortCollaborators)
         },
 
         props: {
@@ -215,6 +223,7 @@
                                     () => {
                                         event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
                                         this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
+                                        this.form.shared.sort(sortCollaborators)
                                         this.alertSuccess("Collaborator added")
                                     },
                                     (error) => {
@@ -224,6 +233,7 @@
                                         if (String(error).includes("OK")) {
                                             event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
                                             this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
+                                            this.form.shared.sort(sortCollaborators)
                                             this.alertSuccess("Collaborator added")
                                         } else {
                                             this.alertError(error)
@@ -332,6 +342,7 @@
                     is_public: this.repository.Public,
                     shared: this.repository.Shared
                 }
+                this.form.shared.sort(sortCollaborators)
                 this.select = {
                     match: null,
                     text: null,

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -165,21 +165,7 @@
                             this.alertSuccess("Collaborator updated")
                         },
                         (error) => {
-                            // TODO this is a hack; this promise always defaults to error,
-                            // even if the REST call returns status OK, but don't see
-                            // the reason at the moment.
-                            if (String(error).includes("OK")) {
-                                event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
-                                for (var i = 0; i < this.form.shared.length; i++) {
-                                    if (this.form.shared[i].User === login_name) {
-                                        this.form.shared[i].AccessLevel = permission
-                                        break
-                                    }
-                                }
-                                this.alertSuccess("Collaborator updated")
-                            } else {
-                                this.alertError(error)
-                            }
+                            this.alertError(error)
                         }
                 )
             },
@@ -227,17 +213,7 @@
                                         this.alertSuccess("Collaborator added")
                                     },
                                     (error) => {
-                                        // TODO this is a hack; this promise always defaults to error,
-                                        // even if the REST call returns status OK, but don't see
-                                        // the reason at the moment.
-                                        if (String(error).includes("OK")) {
-                                            event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
-                                            this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
-                                            this.form.shared.sort(sortCollaborators)
-                                            this.alertSuccess("Collaborator added")
-                                        } else {
-                                            this.alertError(error)
-                                        }
+                                        this.alertError(error)
                                     }
                             )
                         },

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -61,7 +61,7 @@
                                                 <button class="btn btn-danger btn-xs" @click="removeShare(text.User)">remove</button>
                                             </td>
                                         </tr>
-                                        <tr v-if="form.shared.length === 0">
+                                        <tr v-if="form.shared.length === undefined || form.shared.length === 0">
                                             <td>This Repository has no Collaborators</td>
                                         </tr>
                                         </tbody>
@@ -140,7 +140,9 @@
         },
 
         mounted() {
-            this.form.shared.sort(sortCollaborators)
+            if (this.form.shared.length !== undefined) {
+                this.form.shared.sort(sortCollaborators)
+            }
         },
 
         props: {

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -132,6 +132,42 @@
         mixins: [ Alert ],
 
         methods: {
+            updateCollaborator(login_name, permission) {
+                const put_promise = api.repos.putCollaborator(this.$route.params.username,
+                        this.$route.params.repository,
+                        login_name,
+                        { Permission: permission })
+                put_promise.then(
+                        () => {
+                            event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
+                            for (var i = 0; i < this.form.shared.length; i++) {
+                                if (this.form.shared[i].User === login_name) {
+                                    this.form.shared[i].AccessLevel = permission
+                                    break
+                                }
+                            }
+                            this.alertSuccess("Collaborator updated")
+                        },
+                        (error) => {
+                            // TODO this is a hack; this promise always defaults to error,
+                            // even if the REST call returns status OK, but don't see
+                            // the reason at the moment.
+                            if (String(error).includes("OK")) {
+                                event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
+                                for (var i = 0; i < this.form.shared.length; i++) {
+                                    if (this.form.shared[i].User === login_name) {
+                                        this.form.shared[i].AccessLevel = permission
+                                        break
+                                    }
+                                }
+                                this.alertSuccess("Collaborator updated")
+                            } else {
+                                this.alertError(error)
+                            }
+                        }
+                )
+            },
+
             removeShare(login_name) {
                 const promise = api.repos.removeCollaborator(this.$route.params.username,
                         this.$route.params.repository,

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -224,14 +224,21 @@
 
             search(text) {
                 if (text && text.length > 0) {
+                    // TODO currently every new character entered leads to a request to the auth server.
+                    // Check if this could be done more efficiently to reduce either the number of
+                    // requests all together or at least the amount of transferred data using an
+                    // eTag for the account information.
+                    // TODO promise currently does not deal with the reject case.
                     const promise = api.accounts.search(encodeURIComponent(text))
                     promise.then(
                         (accounts) => {
-                            const shared = this.form.shared
+                            const shared = this.form.shared.map(collab => { return collab.User })
                             const owner_login = this.repository.Owner
+
                             accounts = accounts
                                     .filter(acc => !shared.includes(acc.login) && owner_login != acc.login)
                                     .map(acc => { return { label: accountLabel(acc), login: acc.login, active: false}})
+
                             const idx = accounts.findIndex(acc => acc.login === text)
                             if (idx >= 0) {
                                 accounts.splice(idx, 1)

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -45,9 +45,9 @@
                                     <table class="table panel-body">
                                         <tbody>
                                         <tr v-for="text in form.shared">
-                                            <td>{{ text }}</td>
+                                            <td>{{ text.User }}</td>
                                             <td class="text-right">
-                                                <button class="btn btn-danger btn-xs" @click="removeShare(text)">remove</button>
+                                                <button class="btn btn-danger btn-xs" @click="removeShare(text.User)">remove</button>
                                             </td>
                                         </tr>
                                         <tr v-if="form.shared.length === 0">
@@ -156,23 +156,18 @@
                     const promise = api.accounts.get(login_name)
                     promise.then(
                         (acc) => {
-                            // Add account login as collaborator at gin-repo
-                            // This will add the collaborator with the default access level "can-push"
-                            // TODO handle different access levels
                             const put_promise = api.repos.putCollaborator(this.$route.params.username,
                                                                             this.$route.params.repository,
                                                                             login_name,
                                                                             { Permission: "can-pull" })
                             put_promise.then(
                                     () => {
-                                        console.log("proper put")
-                                        this.form.shared = this.form.shared.concat(acc.login)
-                                        this.form.shared.sort()
                                         this.select.match = null
                                         this.select.text = null
                                         this.select.all = []
 
                                         event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
+                                        this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
                                         this.alertSuccess("Collaborator added")
                                     },
                                     (error) => {
@@ -184,10 +179,8 @@
                                         // even if the REST call returns status OK, but don't see
                                         // the reason at the moment.
                                         if (String(error).includes("OK")) {
-                                            console.log("hack put")
-                                            this.form.shared = this.form.shared.concat(acc.login)
-                                            this.form.shared.sort()
                                             event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
+                                            this.form.shared.push({User: login_name, AccessLevel: this.default_permission})
                                             this.alertSuccess("Collaborator added")
                                         } else {
                                             this.alertError(error)

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -121,6 +121,8 @@
         return a.User.localeCompare(b.User)
     }
 
+    var searchBuffer
+
     export default {
         data() {
             return {
@@ -322,7 +324,8 @@
         watch: {
             "select.text": function (search, old) {
                 if (search !== old) {
-                    this.search(search)
+                    clearTimeout(searchBuffer)
+                    searchBuffer = setTimeout(() => {this.search(search)}, 300)
                 }
             }
         }

--- a/src/js/comp/repo/RepoSettings.vue
+++ b/src/js/comp/repo/RepoSettings.vue
@@ -136,7 +136,7 @@
                         login_name)
                 promise.then(
                         () => {
-                            this.form.shared = this.form.shared.filter((n) => n !== login_name)
+                            this.form.shared = this.form.shared.filter((n) => n.User !== login_name)
                             event.emit("repo-update", { username: this.$route.params.username, repository: this.repository.Name })
                             this.alertSuccess("Collaborator removed")
                         },


### PR DESCRIPTION
Depends on G-Node/gin-repo#71

Closes #53.

Additional changes
- repository owners and collaborators with `is-admin` rights can edit collaborators and their repo permissions.
- code cleanup.
- introduces a 300ms delay to the search for available collaborators to reduce the requests to **gin-auth**. Partially addresses #66.
