### PR TITLE
DOI integration

### DIFF
--- a/src/js/comp/Index.vue
+++ b/src/js/comp/Index.vue
@@ -62,7 +62,8 @@
                                     just make your repository publicly available. The data will be accessible but
                                     only you will be able to change it.</li>
                                 <li>share your data with collaborators: you can also share your public or private
-                                    repositories with other users of the GIN service making it easy to jointly work on a project.</li>
+                                    repositories with other users of the GIN service
+                                    making it easy to jointly work on a project.</li>
                             </ul>
                         </li>
                         <li><p class="text-primary"><br/><strong>Version your data</strong></p>
@@ -76,10 +77,10 @@
                             <span class="label label-warning">in development</span></strong></p>
                             <ul>
                                 <li>by indexing the repository contents it's easy to find the files you are looking for.</li>
-                                <li>when using the <a href="https://github.com/G-Node/nix">NIX</a> (Neuroscience Exchange format)
-                                    for scientific data and metadata, even the contents of these files will
-                                    be indexed and searchable making it easy for you to identify even the data
-                                    you are looking for.</li>
+                                <li>when using the <a href="https://github.com/G-Node/nix">NIX</a>
+                                    (Neuroscience Exchange format) for scientific data and metadata,
+                                    even the contents of these files will be indexed and searchable making
+                                    it easy for you to identify even the data you are looking for.</li>
                             </ul>
                         </li>
                         <li><p class="text-primary"><br/><strong>Choose how you want to use our service</strong></p>
@@ -103,17 +104,30 @@
                 </div>
                 <div id="collapse3" class="panel-collapse collapse">
                     <div class="panel-body">
+                        <p>A <a href="https://www.doi.org/">DOI (Digital Object Identifier)</a> <strong>permanently</strong> identifies a resource.</p>
+                        <p>For your research this means:</p>
+                        <ul>
+                            <li>Make any of your data sets <strong>citable</strong>. You will get a permanent link
+                                to the data set you provide. If you use the gin-doi service, your data will be hosted for free.</li>
+                            <li>You can also make your scripts, software, laboratory protocols citable
+                                by giving them a DOI and gaining credit for your work that cannot be normally published.</li>
+                        </ul>
+
+                        <hr>
                         <p>gin-doi is the G-Node Infrastructure DOI service. A Service which can copy your
                             public repository, packs everything into an archive file,
-                            stores it in a super save location and provides you with a DOI such that you can
-                            cite this data. gin-doi fulfills the Data Cite standard which (according to Wikipedia)
-                            tries to:</p>
+                            stores it in a location and provides you with a DOI such that you can
+                            cite this data. gin-doi fulfills the <a href="https://www.datacite.org/">Data Cite</a>
+                            standard which (according to Wikipedia) tries to:</p>
                         <ul>
-                            <li>Establish easier access to research data on the Internet</li>
-                            <li>Increase acceptance of research data as legitimate, citable contributions to the scholarly record</li>
-                            <li>Support data archiving that will permit results to be verified and re-purposed for future study.</li>
+                            <li>Establish easier access to research data on the Internet.</li>
+                            <li>Increase acceptance of research data as legitimate,
+                                citable contributions to the scholarly record.</li>
+                            <li>Support data archiving that will permit results to be verified
+                                and re-purposed for future study.</li>
                         </ul>
-                        <p>You can find datasets already published with the gin-doi service at <a :href="doid">{{ doid }}</a>.</p>
+                        <p>You can find datasets already published with the
+                            gin-doi service at <a :href="doid">{{ doid }}</a>.</p>
                     </div>
                 </div>
                 <div class="panel-heading panel-heading-accordion">
@@ -129,21 +143,23 @@
                     <p>If you want to use our services</p>
                     <ul>
                         <li><a @click="register()">register</a> an account with us.</li>
-                        <li>download the command line client <a href="https://github.com/G-Node/gin-cli">gin-cli</a>.</li>
+                        <li>download the command line client
+                            <a :href="client_dl">gin-cli</a> for your operating system.</li>
                         <li>create a private or a public repository.</li>
-                        <li>upload your data using gin-cli.
+                        <li>upload your data using the client.
                             <!-- deactivated until material can be supplied -->
                             <!-- You can find a tutorial <a href="#">here</a>.
                             <strong><span class="label label-warning">in development</span></strong>
                             -->
                         </li>
-                        <li>access your data via the web services or download them on another machine using gin-cli.</li>
+                        <li>access your data via the web services
+                            or download them on another machine using the command line client.</li>
                     </ul>
                     </div>
                 </div>
                 <div class="panel-heading panel-heading-accordion">
                     <h4 class="panel-title">
-                        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4">
+                        <a data-toggle="collapse" data-parent="#accordion" href="#collapse5">
                             Set up your own in-house GIN service
                             <b class="caret"></b>
                         </a>

--- a/src/js/comp/Index.vue
+++ b/src/js/comp/Index.vue
@@ -72,14 +72,6 @@
                             </ul>
                         </li>
 
-                        <li><p class="text-primary"><br/><strong>Publish your data (DOI)
-                            <span class="label label-warning">in development</span></strong></p>
-                            <ul>
-                                <li>when you are hosting your data on the GIN server, we give you the option
-                                    to publish any of your public repositories. We will issue a DOI reliably hosting
-                                    your data for your publications.</li>
-                            </ul>
-                        </li>
                         <li><p class="text-primary"><br/><strong>Enhanced search of your repositories
                             <span class="label label-warning">in development</span></strong></p>
                             <ul>
@@ -100,15 +92,39 @@
                     </ul>
                 </div>
                 </div>
+
                 <div class="panel-heading panel-heading-accordion">
                     <h4 class="panel-title">
                         <a data-toggle="collapse" data-parent="#accordion" href="#collapse3">
-                            How to use the G-Node GIN services
+                            Publish your data (DOI)
                             <b class="caret"></b>
                         </a>
                     </h4>
                 </div>
                 <div id="collapse3" class="panel-collapse collapse">
+                    <div class="panel-body">
+                        <p>gin-doi is the G-Node Infrastructure DOI service. A Service which can copy your
+                            public repository, packs everything into an archive file,
+                            stores it in a super save location and provides you with a DOI such that you can
+                            cite this data. gin-doi fulfills the Data Cite standard which (according to Wikipedia)
+                            tries to:</p>
+                        <ul>
+                            <li>Establish easier access to research data on the Internet</li>
+                            <li>Increase acceptance of research data as legitimate, citable contributions to the scholarly record</li>
+                            <li>Support data archiving that will permit results to be verified and re-purposed for future study.</li>
+                        </ul>
+                        <p>You can find datasets already published with the gin-doi service at <a :href="doid">{{ doid }}</a>.</p>
+                    </div>
+                </div>
+                <div class="panel-heading panel-heading-accordion">
+                    <h4 class="panel-title">
+                        <a data-toggle="collapse" data-parent="#accordion" href="#collapse4">
+                            How to use the G-Node GIN services
+                            <b class="caret"></b>
+                        </a>
+                    </h4>
+                </div>
+                <div id="collapse4" class="panel-collapse collapse">
                     <div class="panel-body">
                     <p>If you want to use our services</p>
                     <ul>
@@ -133,7 +149,7 @@
                         </a>
                     </h4>
                 </div>
-                <div id="collapse4" class="panel-collapse collapse">
+                <div id="collapse5" class="panel-collapse collapse">
                     <div class="panel-body">
                         <div class="bs-callout bs-callout-primary">
                             <div class="container"><div class="row">
@@ -172,6 +188,9 @@
             },
             contact: function() {
                 return window.api.config.contact_email
+            },
+            doid: function() {
+                return window.api.config.doid_url
             },
         },
 

--- a/src/js/comp/Index.vue
+++ b/src/js/comp/Index.vue
@@ -12,6 +12,10 @@
     <div>
         <h1>Welcome to the G-Node Neuroscience Data Infrastructure services</h1>
         <hr />
+        <div class="bs-callout bs-callout-success">
+            <a @click="register()">Register</a> an account with us, download the command line client
+            <a :href="client_dl">gin-cli</a> for your operating system and start using our services.
+        </div>
 
         <div class="panel-group" id="accordion">
             <div class="panel panel-default">
@@ -208,6 +212,9 @@
             doid: function() {
                 return window.api.config.doid_url
             },
+            client_dl: function() {
+                return window.api.config.client_dl
+            }
         },
 
         methods: {

--- a/src/js/comp/account/ReposOwn.vue
+++ b/src/js/comp/account/ReposOwn.vue
@@ -24,6 +24,7 @@
                     </div>
                     <div class="panel-body">
                         {{ repo.Description }}
+                        <span v-if="!repo.Description">No description for this repository.</span>
                     </div>
                 </div>
             </li>

--- a/src/js/comp/account/ReposOwn.vue
+++ b/src/js/comp/account/ReposOwn.vue
@@ -18,10 +18,12 @@
                                             params: { username: repo.Owner, repository: repo.Name } }">
                             {{ repo.Owner }}/{{ repo.Name }}
                         </router-link>
+
+                        <strong v-if="repo.Public"><span class="label label-success pull-right">public</span></strong>
+                        <strong v-if="!repo.Public"><span class="label label-danger pull-right">private</span></strong>
                     </div>
                     <div class="panel-body">
-                        {{ repo.Description }} <br/> <br/>
-                        {{ repo.Public | privacyLabel }}
+                        {{ repo.Description }}
                     </div>
                 </div>
             </li>

--- a/src/js/comp/account/ReposShared.vue
+++ b/src/js/comp/account/ReposShared.vue
@@ -18,11 +18,12 @@
                                             params: { username: repo.Owner, repository: repo.Name } }">
                             {{ repo.Owner }}/{{ repo.Name }}
                         </router-link>
+
+                        <strong v-if="repo.Public"><span class="label label-success pull-right">public</span></strong>
+                        <strong v-if="!repo.Public"><span class="label label-danger pull-right">private</span></strong>
                     </div>
                     <div class="panel-body">
-                        Owner {{ repo.FullName }}<br/>
-                        {{ repo.Public | privacyLabel }}
-                        <br/><br/>
+                        Owner {{ repo.FullName }}<br/><br/>
                         {{ repo.Description }}
                         <span v-if="!repo.Description">No description for this repository.</span>
                     </div>

--- a/src/js/comp/info/DOI.vue
+++ b/src/js/comp/info/DOI.vue
@@ -1,0 +1,17 @@
+<!--
+    Copyright (c) 2017, German Neuroinformatics Node (G-Node)
+
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted under the terms of the BSD License. See
+    LICENSE file in the root of the Project.
+-->
+
+<template>
+    <div class="container">
+    </div>
+</template>
+
+<script>
+</script>

--- a/src/js/comp/info/DOI.vue
+++ b/src/js/comp/info/DOI.vue
@@ -9,9 +9,124 @@
 -->
 
 <template>
-    <div class="container">
+    <div class="container main-container">
+        <h2>The DOI request file</h2>
+        <hr/>
+
+        <p>To request a DOI for a repository, you need to provide a file in the machine readable
+            <a href="https://en.wikipedia.org/wiki/YAML">YAML</a> format in the root of the repository.</p>
+        <p>This file has to be named <code>{{ doi_file }}</code> and has to contain the following entries:</p>
+
+        <ul>
+            <li>authors</li>
+            <li>title</li>
+            <li>description</li>
+            <li>keywords</li>
+            <li>license</li>
+            <li>references</li>
+        </ul>
+        <p>You can find an example file <a :href="doi_example">here</a>.</p>
+        <p>
+            You can check on <a href="http://www.yamllint.com">yamllint.com</a> if your file
+            is a formally correct YAML file before you upload it to a repository.
+        </p>
+
+        <h2>Keyword description</h2>
+        <hr/>
+        <p>Note that the keys (authors, title, description, etc.) need to be lower case, followed by a colon
+            and the corresponding content.<br/></p>
+
+        <h3>authors</h3>
+        <hr/>
+        <p>
+            <code>authors</code> are the main researchers involved working on the data,
+            or the authors of the publication in priority order. It may be a corporate/institutional
+            or personal name.<br/>
+            Please provide the authors as list items, each item indented and prefixed with <code>-</code>.
+            <br/><br/>
+            <pre>
+                authors:
+                  - FamilyName1, GivenName1, Institution1, Department1
+                  - FamilyName2, GivenName2, Institution2, Department2
+                  - FamilyName3, GivenName3
+            </pre>
+        </p>
+
+        <h3>title</h3>
+        <hr/>
+        <p>
+            <code>title</code> is a descriptive name of the data set to be published.
+            Do not use linebreaks in the title.
+            <br/><br/>
+            <pre>
+                title: Example Title
+            </pre>
+        </p>
+
+        <h3>description</h3>
+        <hr/>
+        <p>
+            <code>description</code> contains any extended information about your dataset.
+            <br/><br/>
+            <pre>
+                description: |
+                    Example description
+                    that can contain linebreaks
+                    but has to maintain indentation.
+            </pre>
+        </p>
+
+        <h3>keywords</h3>
+        <hr/>
+        <p>
+            <code>keywords</code> is a list of buzzwords the dataset is associated with.
+            <br/><br/>
+            <pre>
+                keywords:
+                    - Neuroscience
+                    - Electrophysiology
+            </pre>
+        </p>
+
+        <h3>license</h3>
+        <hr/>
+        <p>
+            <code>license</code> is the license under which the dataset will be published.
+            Examples of open licenses are
+            <ul>
+                <li>CC0 (<a href="http://creativecommons.org/publicdomain/zero/1.0/">
+                    http://creativecommons.org/publicdomain/zero/1.0/</a>)</li>
+                <li>CC-BY (<a href="http://creativecommons.org/licenses/by/4.0/">
+                    http://creativecommons.org/licenses/by/4.0/</a>)</li>
+            </ul>
+
+            <pre>
+                license: CC0
+            </pre>
+        </p>
+
+        <h3>references</h3>
+        <hr/>
+        <p>
+            <code>references</code> are additional references associated with the data publication.
+            <br/><br/>
+            <pre>
+                references:
+                    - Example et. al.
+            </pre>
+        </p>
     </div>
 </template>
 
 <script>
+    export default {
+        computed: {
+            doi_file: function () {
+                return window.api.config.doi_file
+            },
+            doi_example: function() {
+                return window.api.config.doi_example
+            }
+        },
+    }
 </script>

--- a/src/js/comp/info/DOI.vue
+++ b/src/js/comp/info/DOI.vue
@@ -84,7 +84,7 @@
             <pre>
                 keywords:
                     - Neuroscience
-                    - Electrophysiology
+                    - Pseudoscience
             </pre>
         </p>
 
@@ -111,8 +111,7 @@
             <code>references</code> are additional references associated with the data publication.
             <br/><br/>
             <pre>
-                references:
-                    - Example et. al.
+                references: Example1 et. al., Example2 et. al., ...
             </pre>
         </p>
     </div>

--- a/src/js/comp/repo/Repo.vue
+++ b/src/js/comp/repo/Repo.vue
@@ -30,15 +30,12 @@
                     Files
                 </router-link>
             </li>
-            <!-- deactivated until proper DOI content is available -->
-            <!--
             <li role="presentation" v-if="is_repo_owned">
                 <router-link :to="{ name: 'repository-doi',
                         params: { username: $route.params.username, repository: $route.params.repository }}">
                     DOI
                 </router-link>
             </li>
-            -->
             <li role="presentation" :class="{ 'active': $route.name === 'repository-settings' }"
                                     v-if="is_repo_writeable">
                 <router-link :to="{ name: 'repository-settings',

--- a/src/js/comp/repo/RepoDOI.vue
+++ b/src/js/comp/repo/RepoDOI.vue
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016, German Neuroinformatics Node (G-Node)
+    Copyright (c) 2017, German Neuroinformatics Node (G-Node)
 
     All rights reserved.
 
@@ -113,13 +113,18 @@
         data() {
             return {
                 can_doi: null,
-                doi_file: null,
                 message: null
             }
         },
 
         mounted() {
             this.update(this.$route.params)
+        },
+
+        computed: {
+            doi_file: function() {
+                return window.api.config.doi_file
+            }
         },
 
         props: {
@@ -141,7 +146,6 @@
 
             update(params) {
                 this.can_doi = false
-                this.doi_file = window.api.config.doi_file
                 this.message = "one"
 
                 var acc = (this.account !== undefined && this.account !== null)

--- a/src/js/comp/repo/RepoDOI.vue
+++ b/src/js/comp/repo/RepoDOI.vue
@@ -134,8 +134,7 @@
                 console.log("[RepoDOI] create DOI")
                 // TODO Currently only the master branch is handled.
                 // TODO Once different branches are supported, this has to be changed as well.
-                window.api.repos.requestDOI(this.account.login,
-                        this.$route.params.username,
+                window.api.repos.requestDOI(this.$route.params.username,
                         this.$route.params.repository,
                         "master")
             },

--- a/src/js/comp/repo/RepoDOI.vue
+++ b/src/js/comp/repo/RepoDOI.vue
@@ -33,11 +33,9 @@
                             <li>
                                 that the information in your <code>{{ doi_file }}</code> file contains all
                                 information required to successfully submit your data to a DOI agency.
-                                <!-- Deactivated until material can be supplied -->
-                                <!--
-                                    If you are unsure, you can read up on the details <a href="#">here</a> before proceeding.
-                                    <span class="label label-warning">Under construction</span>
-                                -->
+
+                                If you are unsure, you can read up on the details
+                                <router-link :to="{ name: 'doi' }">here</router-link> before proceeding.
                             </li>
                         </ul>
                     </div>
@@ -56,8 +54,8 @@
                     <div v-if="message == 'one'">
                         This repository is <strong>private</strong>.
                         <hr>
-                        <p>A DOI can only be requested for a <strong>public</strong> repository</p>
-                        <p>Please change the repository visibility to public under the Settings tab before proceeding.</p>
+                        <p>A DOI can only be requested for a <strong>public</strong> repository.</p>
+                        <p>Please change the repository visibility to public at the Settings tab before proceeding.</p>
                     </div>
 
                     <!-- handle missing doi_file -->
@@ -65,41 +63,47 @@
                         Your repository is missing the DOI request file.
                         <hr>
                         <p>In order to request a DOI, the root of your repository must contain a file
-                            named <code>{{ doi_file }}</code>.</p>
-                        <p>This file has to contain information about yourself and your project.</p>
-                        <p>Please add this file to the root of your repository before proceeding.</p>
-
-                        <!-- Deactivated until material can be supplied -->
-                        <!--
-                            <hr>
-
-                            <p>You can find a description about the content of this request file <a href="#">here</a>.
-                                <span class="label label-warning">Under construction</span></p>
-                            <p>You can download an example file <a href="#">here</a>.
-                                <span class="label label-warning">Under construction</span></p>
-                        -->
-
+                            named <code>{{ doi_file }}</code>. Please add this file to the
+                            root of your repository before proceeding.</p>
                     </div>
                 </div>
             </div>
-            <!-- Deactivated until material can be supplied -->
-            <!--
-                <div class="panel-heading">
-                    What is a DOI and why would I want one?
-                </div>
-                <div class="panel-body">
-                    DOI's are ... <span class="label label-warning">Under construction</span>
-                </div>
-            -->
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                How to get a DOI
+            </div>
+            <div class="panel-body">
+                <ul>
+                    <li>Make the repository <strong>public</strong>.</li>
+                    <li>Provide a valid DOI request file called <code>{{ doi_file }}</code>
+                        at the root of the repository.</li>
+                    <li>Hit "Submit" and follow the instructions on gin-doi.</li>
+                </ul>
+                <ul>
+                    <li>Here you can find a <router-link :to="{ name: 'doi' }">
+                        detailed description about the DOI request file</router-link>.</li>
+                    <li>You can also download an <a :href="doi_example">example DOI request file</a>.</li>
+                </ul>
+            </div>
+        </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                What is a DOI and why would I want one?
+            </div>
+            <div class="panel-body">
+                <p>A <a href="https://www.doi.org/">DOI (Digital Object Identifier)</a> <strong>permanently</strong> identifies a resource.</p>
+                <p>For your research this means:</p>
+                <ul>
+                    <li>Make any of your data sets <strong>citable</strong>. You will get a permanent link
+                    to the data set you provide. If you use the gin-doi service, your data will be hosted for free.</li>
+                    <li>You can also make your scripts, software, laboratory protocols citable
+                    by giving them a DOI and gaining credit for your work that cannot be normally published.</li>
+                </ul>
+                <p>Note that you cannot change or remove a resource once a DOI has been assigned to it.</p>
+            </div>
         </div>
 
-        <!-- Deactivated until material can be supplied -->
-        <!--
-        <div class="row">
-            <div class="col-sm-3"><span class="label label-info">Page under development</span></div>
-            <div class="col-sm-9"></div>
-        </div>
-        -->
     </div>
 </template>
 
@@ -124,6 +128,9 @@
         computed: {
             doi_file: function() {
                 return window.api.config.doi_file
+            },
+            doi_example: function() {
+                return window.api.config.doi_example
             }
         },
 

--- a/src/js/comp/search/Search.vue
+++ b/src/js/comp/search/Search.vue
@@ -30,7 +30,7 @@
                             Repositories ({{ public_repo.length }})
                         </router-link>
                     </li>
-                    <li role="presentation" :class="{ 'active': $route.name === 'search-users' }">
+                    <li v-if="has_login" role="presentation" :class="{ 'active': $route.name === 'search-users' }">
                         <router-link :to="{ name: 'search-users' }">
                             Users ({{ users.length }})
                         </router-link>
@@ -56,7 +56,8 @@
             return {
                 users: null,
                 search_text: null,
-                public_repo: null
+                public_repo: null,
+                has_login: null
             }
         },
 
@@ -66,6 +67,10 @@
 
         methods: {
             search() {
+                // TODO looking for a token in localStorage is a workaround the race condition
+                // with account in APP.vue. Refactor when race condition issue has been addressed.
+                // Enable "Users" tab dependent on login.
+                (localStorage.getItem("token") !== null) ? this.has_login = true : this.has_login = false
 
                 const all_public = api.repos.listPublic()
                 all_public.then(

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -3,6 +3,7 @@
   "repo_url": "http://localhost:8082",
   "doi_url": "http://localhost:8083",
   "doi_file": "cloudberry.yml",
+  "doi_example": "/dl/cloudberry.yml",
   "doid_url": "http://doid.gin.g-node.org",
   "client_id": "gin",
   "client_secret": "secret",

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -5,6 +5,7 @@
   "doi_file": "cloudberry.yml",
   "doi_example": "/dl/cloudberry.yml",
   "doid_url": "http://doid.gin.g-node.org",
+  "client_dl": "https://web.gin.g-node.org/release/",
   "client_id": "gin",
   "client_secret": "secret",
   "contact_email": "dev@example.com"

--- a/src/js/config.json
+++ b/src/js/config.json
@@ -3,6 +3,7 @@
   "repo_url": "http://localhost:8082",
   "doi_url": "http://localhost:8083",
   "doi_file": "cloudberry.yml",
+  "doid_url": "http://doid.gin.g-node.org",
   "client_id": "gin",
   "client_secret": "secret",
   "contact_email": "dev@example.com"

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -14,6 +14,7 @@ export default class API {
                             repo_url: conf.repo_url,
                             doi_url: conf.doi_url,
                             doi_file: conf.doi_file,
+                            doid_url: conf.doid_url,
                             client_id: conf.client_id,
                             client_secret: conf.client_secret,
                             contact_email: conf.contact_email,

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -482,7 +482,9 @@ class RepoAPI {
     requestDOI(owner, repo, branch) {
         const uri = this.config.doi_url + "?"
         const kv = [
-            ["repo", branch+":"+owner+"/"+repo]
+            ["repo", branch+":"+owner+"/"+repo],
+            ["user", this.config.token.login],
+            ["token", "Bearer "+ this.config.token.jti]
         ]
         const query = kv.map((p) => encodeURIComponent(p[0]) + "=" + encodeURIComponent(p[1])).join("&")
 

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -16,6 +16,7 @@ export default class API {
                             doi_file: conf.doi_file,
                             doi_example: conf.doi_example,
                             doid_url: conf.doid_url,
+                            client_dl: conf.client_dl,
                             client_id: conf.client_id,
                             client_secret: conf.client_secret,
                             contact_email: conf.contact_email,

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -14,6 +14,7 @@ export default class API {
                             repo_url: conf.repo_url,
                             doi_url: conf.doi_url,
                             doi_file: conf.doi_file,
+                            doi_example: conf.doi_example,
                             doid_url: conf.doid_url,
                             client_id: conf.client_id,
                             client_secret: conf.client_secret,

--- a/src/js/data.js
+++ b/src/js/data.js
@@ -476,13 +476,10 @@ class RepoAPI {
         })
     }
 
-    requestDOI(user, owner, repo, branch) {
+    requestDOI(owner, repo, branch) {
         const uri = this.config.doi_url + "?"
         const kv = [
-            ["user", user],
-            ["owner", owner],
-            ["repo", repo],
-            ["branch", branch]
+            ["repo", branch+":"+owner+"/"+repo]
         ]
         const query = kv.map((p) => encodeURIComponent(p[0]) + "=" + encodeURIComponent(p[1])).join("&")
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -45,6 +45,7 @@ import Terms                from "./comp/info/Terms.vue"
 import About                from "./comp/info/About.vue"
 import Contact              from "./comp/info/Contact.vue"
 import Imprint              from "./comp/info/Imprint.vue"
+import DOI                  from "./comp/info/DOI.vue"
 
 import config               from "./config.json"
 
@@ -77,6 +78,7 @@ const router = new VueRouter({
         { path: "/info/about", component: About, name: "about" },
         { path: "/info/contact", component: Contact, name: "contact" },
         { path: "/info/imprint", component: Imprint, name: "imprint" },
+        { path: "/info/doi", component: DOI, name: "doi" },
 
         { path: "/account/settings", component: Settings,
             children: [


### PR DESCRIPTION
This pull request
- adds submission of a repository to the gin-doi service.
- adds DOI information to the DOI request and the gin-ui main page.
- adds gin-cli download links at the gin-ui main page.
- adds repository visibility label to own and shared repository lists.
- displays a message at own an shared repository lists when no repo description is available.
- hides the "User" tab in repository search, if there is no valid login.

Closes #52, #82, #88.